### PR TITLE
Add basic server for form submissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+submissions/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # e-application
-user fills out form and submits to predefined recipient email address
+
+This project contains a client-side form for collecting sea experience data. A small Node.js server is provided to handle submissions so that multiple users can submit the form without interfering with each other. Each submission is stored as a separate file on the server.
+
+## Running the Server
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the server:
+   ```bash
+   npm start
+   ```
+   The form is served at `http://localhost:3000/e-app-202506040528.html`.
+
+Submitted data will be saved in the `submissions/` directory with a unique timestamped filename.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "e-application-server",
+  "version": "1.0.0",
+  "description": "Simple server for e-application form",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,33 @@
+const express = require('express');
+const path = require('path');
+const fs = require('fs');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+// Serve the static HTML file
+app.use(express.static(__dirname));
+app.use(express.json());
+
+const submissionsDir = path.join(__dirname, 'submissions');
+if (!fs.existsSync(submissionsDir)) {
+  fs.mkdirSync(submissionsDir);
+}
+
+app.post('/submit', (req, res) => {
+  const data = req.body;
+  const fileName = `submission-${Date.now()}.json`;
+  const filePath = path.join(submissionsDir, fileName);
+
+  fs.writeFile(filePath, JSON.stringify(data, null, 2), (err) => {
+    if (err) {
+      console.error('Error saving submission:', err);
+      return res.status(500).json({ success: false });
+    }
+    res.json({ success: true });
+  });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- create Node.js server with Express to handle form submissions
- store submissions as JSON files per user
- add package.json and .gitignore
- update README with server instructions

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: Cannot find module 'express')*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683f6d87294c8325b1518c66851ccc7b