### PR TITLE
Enable PDF email on form submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,18 @@ This project contains a client-side form for collecting sea experience data. A s
    ```
    The form is served at `http://localhost:3000/e-app-202506040528.html`.
 
-Submitted data will be saved in the `submissions/` directory with a unique timestamped filename.
+Submitted data will be saved in the `submissions/` directory with a unique timestamped filename. In addition, a PDF copy of each submission is generated and emailed to the address defined in your environment variables using Nodemailer.
+
+### Email Configuration
+
+Set the following environment variables before starting the server:
+
+```
+EMAIL_HOST   - SMTP host
+EMAIL_PORT   - SMTP port (e.g. 587)
+EMAIL_SECURE - 'true' for secure (TLS) connection
+EMAIL_USER   - SMTP username
+EMAIL_PASS   - SMTP password
+EMAIL_FROM   - Sender address
+EMAIL_TO     - Recipient address
+```

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "nodemailer": "^6.9.9",
+    "pdfkit": "^0.15.1"
   }
 }


### PR DESCRIPTION
## Summary
- integrate **nodemailer** and **pdfkit**
- generate a PDF from the submitted data
- email the PDF to a predefined recipient
- document email configuration in README

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_683f71238d608325b9cfed6b4eefeda0