### PR TITLE
Add env example file and update README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Environment variables for e-application server
+EMAIL_HOST=smtp.example.com
+EMAIL_PORT=587
+EMAIL_SECURE=false
+EMAIL_USER=user@example.com
+EMAIL_PASS=changeme
+EMAIL_FROM=from@example.com
+EMAIL_TO=to@example.com

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 submissions/
+.env

--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@ This project contains a client-side form for collecting sea experience data. A s
    ```bash
    npm install
    ```
-2. Start the server:
+2. Copy `.env.example` to `.env` and update the values as needed:
+   ```bash
+   cp .env.example .env
+   # then edit .env
+   ```
+3. Start the server:
    ```bash
    npm start
    ```
@@ -18,7 +23,7 @@ Submitted data will be saved in the `submissions/` directory with a unique times
 
 ### Email Configuration
 
-Set the following environment variables before starting the server:
+Set the following values in your `.env` file before starting the server:
 
 ```
 EMAIL_HOST   - SMTP host


### PR DESCRIPTION
## Summary
- provide `.env.example` with email config placeholders
- ignore local `.env` files
- document env setup in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f77580d2883259054a3f7d5c978aa