### PR TITLE
Add CODEOWNERS and workflow docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Code owners for automated review assignment
+/server.js @backend-team
+/*.html @frontend-team
+* @maintainers

--- a/README.md
+++ b/README.md
@@ -29,3 +29,13 @@ EMAIL_PASS   - SMTP password
 EMAIL_FROM   - Sender address
 EMAIL_TO     - Recipient address
 ```
+
+## Branching Workflow
+
+1. Create a feature branch from `main` with a descriptive name, such as
+   `feature/update-form`.
+2. Commit small, focused changes and push the branch to GitHub.
+3. Open a Pull Request against `main`. Reviewers are assigned automatically via
+   the CODEOWNERS file.
+4. Ensure all checks pass and obtain at least one approval before merging.
+5. Delete the feature branch after the PR is merged.


### PR DESCRIPTION
## Summary
- assign code owners for `/server.js` and other files
- describe the feature branch workflow in the README

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_683f774fabe88325a7683cf645b06263