### PR TITLE
Add Jest tests and CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,18 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm install
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -4,11 +4,16 @@
   "description": "Simple server for e-application form",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "jest"
   },
   "dependencies": {
     "express": "^4.19.2",
     "nodemailer": "^6.9.9",
     "pdfkit": "^0.15.1"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
   }
 }

--- a/server.js
+++ b/server.js
@@ -73,6 +73,10 @@ app.post('/submit', async (req, res) => {
   }
 });
 
-app.listen(PORT, () => {
-  console.log(`Server running on port ${PORT}`);
-});
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Server running on port ${PORT}`);
+  });
+}
+
+module.exports = { app, generatePDF, sendEmail };

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,0 +1,43 @@
+const request = require('supertest');
+const fs = require('fs');
+
+jest.mock('fs');
+
+const serverModule = require('../server');
+const { app } = serverModule;
+
+beforeEach(() => {
+  jest.spyOn(global.Date, 'now').mockReturnValue(123456789); // deterministic filename
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test('POST /submit returns success on valid submission', async () => {
+  fs.writeFileSync.mockImplementation(() => {});
+  jest.spyOn(serverModule, 'generatePDF').mockResolvedValue();
+  jest.spyOn(serverModule, 'sendEmail').mockResolvedValue();
+
+  const res = await request(app)
+    .post('/submit')
+    .send({ name: 'test' })
+    .expect('Content-Type', /json/)
+    .expect(200);
+
+  expect(res.body).toEqual({ success: true });
+});
+
+test('POST /submit returns 500 on failure', async () => {
+  fs.writeFileSync.mockImplementation(() => {
+    throw new Error('disk error');
+  });
+  const res = await request(app)
+    .post('/submit')
+    .send({ name: 'bad' })
+    .expect('Content-Type', /json/)
+    .expect(500);
+
+  expect(res.body).toEqual({ success: false });
+});
+


### PR DESCRIPTION
## Summary
- add Jest and Supertest setup for testing the Express app
- export app from server for testing
- add basic unit tests for POST `/submit`
- wire up `npm test` script
- run tests in GitHub Actions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f775fa8808325be5529b07e0c7755