### PR TITLE
Implement email submission with PHPMailer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+vendor/

--- a/README.md
+++ b/README.md
@@ -22,3 +22,22 @@ Use `npm run build` to generate a production build and `npm run preview` to serv
 ## User Manual
 
 See [USER_MANUAL.md](USER_MANUAL.md) for a walkthrough of the form workflow, navigation and data persistence.
+
+## Email Submission Backend
+
+The "Submit & Email" button on the sea experience page sends the collected form
+data to `submit_application.php`. The script uses **PHPMailer** to deliver the
+application via SMTP. To enable this feature you need PHP 8+ and Composer
+installed locally.
+
+Run `composer install` in the project root to install PHPMailer and set the
+following environment variables for your SMTP server:
+
+- `SMTP_HOST`
+- `SMTP_USER`
+- `SMTP_PASS`
+- `SMTP_PORT` (defaults to 465 if unset)
+- `APPLICATION_RECEIVER` – email address that receives the submissions
+
+Once configured, serve the project with a PHP-capable server so the PHP script
+can run when the form is submitted.

--- a/camiip2.html
+++ b/camiip2.html
@@ -464,6 +464,7 @@
 
   <script>
     const STORAGE_KEY_SEA_EXPERIENCE = 'seaExperienceFormData_v2'; // v2 to avoid conflicts if old data format exists
+    const STORAGE_KEY_MAIN_FORM = 'mainApplicationFormData';
     const MAX_EXPERIENCES = 15;
 
     function saveSeaExperienceData() {
@@ -949,7 +950,32 @@
         });
 
       console.log('Form data for submission:', data);
-      alert('Form data prepared for submission. See console for details. Implement actual submission logic.');
+
+      const personalData = localStorage.getItem(STORAGE_KEY_MAIN_FORM);
+      const payload = {
+        personal: personalData ? JSON.parse(personalData) : {},
+        experiences: data.experiences
+      };
+
+      fetch('submit_application.php', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      })
+      .then(response => response.json())
+      .then(res => {
+        if (res.status === 'ok') {
+          alert('Application submitted successfully.');
+          localStorage.removeItem(STORAGE_KEY_MAIN_FORM);
+          localStorage.removeItem(STORAGE_KEY_SEA_EXPERIENCE);
+        } else {
+          alert('Submission failed: ' + (res.message || 'Unknown error'));
+        }
+      })
+      .catch(err => {
+        console.error('Submission error', err);
+        alert('Unable to submit application.');
+      });
     });
   </script>
 </body>

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+  "require": {
+    "phpmailer/phpmailer": "^6.9"
+  }
+}

--- a/submit_application.php
+++ b/submit_application.php
@@ -1,0 +1,57 @@
+<?php
+require __DIR__ . '/vendor/autoload.php';
+
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\Exception;
+
+header('Content-Type: application/json');
+
+try {
+    $raw = file_get_contents('php://input');
+    $payload = json_decode($raw, true);
+    if (!$payload) {
+        http_response_code(400);
+        echo json_encode(['status' => 'error', 'message' => 'Invalid JSON payload']);
+        exit;
+    }
+
+    $mail = new PHPMailer(true);
+
+    $mail->isSMTP();
+    $mail->Host = getenv('SMTP_HOST');
+    $mail->SMTPAuth = true;
+    $mail->Username = getenv('SMTP_USER');
+    $mail->Password = getenv('SMTP_PASS');
+    $mail->SMTPSecure = PHPMailer::ENCRYPTION_SMTPS;
+    $mail->Port = getenv('SMTP_PORT') ?: 465;
+
+    $from = getenv('SMTP_USER');
+    $mail->setFrom($from, 'CAMII Application');
+    $receiver = getenv('APPLICATION_RECEIVER');
+    if ($receiver) {
+        $mail->addAddress($receiver);
+    } else {
+        $mail->addAddress($from);
+    }
+
+    $mail->isHTML(true);
+    $mail->Subject = 'New CAMII Application';
+
+    ob_start();
+    echo '<h2>Personal Information</h2>';
+    if (!empty($payload['personal'])) {
+        echo '<pre>' . htmlspecialchars(print_r($payload['personal'], true)) . '</pre>';
+    }
+    echo '<h2>Sea Experience</h2>';
+    if (!empty($payload['experiences'])) {
+        echo '<pre>' . htmlspecialchars(print_r($payload['experiences'], true)) . '</pre>';
+    }
+    $mail->Body = ob_get_clean();
+
+    $mail->send();
+
+    echo json_encode(['status' => 'ok']);
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['status' => 'error', 'message' => $e->getMessage()]);
+}


### PR DESCRIPTION
## Summary
- create `submit_application.php` using PHPMailer
- update sea experience form to POST JSON to the PHP endpoint
- document SMTP configuration and composer install steps
- add `composer.json` and ignore generated vendor directory

## Testing
- `npm run build` *(fails: vite not found)*
- `php -l submit_application.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858f072bda08325b641a6dd7dccaa87