### PR TITLE
Add SMTP env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Copy to .env and replace placeholders with real values
+SMTP_HOST=smtp.example.com
+SMTP_USER=user@example.com
+SMTP_PASS=your_password
+SMTP_PORT=465
+APPLICATION_RECEIVER=receiver@example.com

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ application via SMTP. To enable this feature you need PHP 8+ and Composer
 installed locally.
 
 Run `composer install` in the project root to install PHPMailer and set the
-following environment variables for your SMTP server:
+following environment variables for your SMTP server (see
+[.env.example](.env.example) for a template):
 
 - `SMTP_HOST`
 - `SMTP_USER`


### PR DESCRIPTION
## Summary
- document SMTP configuration in `.env.example`
- cross-reference the example file in README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858f9fbe90c83258faf1531b56cd2db