### PR TITLE
Fix navigation to next page

### DIFF
--- a/index.html
+++ b/index.html
@@ -514,13 +514,12 @@
                     </div>
                 </div>
                 <div class="flex justify-center mt-8 mb-5">
-                     <button type="button" id="nextPageButton" class="bg-cami-blue hover:bg-cami-blue-dark text-white font-semibold py-2.5 px-6 rounded-md text-sm transition duration-150 ease-in-out">Next Page</button>
+                     <a href="camiip2.html" id="nextPageButton" class="bg-cami-blue hover:bg-cami-blue-dark text-white font-semibold py-2.5 px-6 rounded-md text-sm transition duration-150 ease-in-out inline-flex items-center justify-center">Next Page</a>
                 </div>
             </form>
         </div>
     </div>
     <!-- Flatpickr JS removed -->
-    <script type="module" src="index.tsx"></script>
-<script type="module" src="/index.tsx"></script>
+    <script type="module" src="/index.tsx"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update `Next Page` button to be a normal link so navigation works even if scripts fail
- load the main script once using the root path

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859004cfa38832590f1f6017514132f