### PR TITLE
Add MySQL support to CAMII E‑Application

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,7 @@ SMTP_USER=user@example.com
 SMTP_PASS=your_password
 SMTP_PORT=465
 APPLICATION_RECEIVER=receiver@example.com
+DB_HOST=127.0.0.1
+DB_USER=root
+DB_PASS=
+DB_NAME=camii_app

--- a/README.md
+++ b/README.md
@@ -1,43 +1,43 @@
 # E-Application for CAMII
 
-This project is a Vite-based web application used for collecting personal and sea service information for Cebu Ace-Maritime International Inc. It is written in TypeScript and stores form data in the browser so users can complete the application over multiple sessions.
+This project collects applicant information for Cebu Ace-Maritime International Inc. The front end is a Vite based form written in TypeScript. Submitted data is saved to a MySQL database and emailed via PHPMailer.
 
-## Running Locally
+## Prerequisites
 
-**Prerequisites:** Node.js 18+
+- [XAMPP](https://www.apachefriends.org) with PHP 8 and MySQL
+- Node.js 18+
+- Composer
 
-1. Install dependencies with `npm install`.
-2. Start a development server with `npm run dev` and open the printed URL in a browser.
+## Setup
 
-Use `npm run build` to generate a production build and `npm run preview` to serve the built files.
+1. Copy `.env.example` to `.env` and provide SMTP and database credentials.
+2. Create a MySQL database (default name `camii_app`). Example schema:
+
+   ```sql
+   CREATE TABLE applications (
+     id INT AUTO_INCREMENT PRIMARY KEY,
+     personal LONGTEXT,
+     experiences LONGTEXT,
+     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+   );
+   ```
+3. Place this project inside XAMPP's `htdocs` directory or configure a virtual host.
+4. Start Apache and MySQL from the XAMPP control panel.
+5. Install PHP dependencies with `composer install`.
+6. Install Node dependencies with `npm install` and start the dev server using `npm run dev`.
+
+## Usage
+
+- Open `http://localhost:5173` to fill out the forms.
+- The **Submit & Email** button sends data to `submit_application.php`. The script saves the submission in MySQL and emails a copy via SMTP.
+
+Use `npm run build` to create a production build and `npm run preview` to serve the built files.
 
 ## Repository Structure
 
 - `index.html` / `index.tsx` – personal information form
 - `camiip2.html` – sea experience form
-- `index.css` – shared styling
+- `submit_application.php` – handles email and database storage
 - `USER_MANUAL.md` – detailed usage instructions
 
-## User Manual
-
-See [USER_MANUAL.md](USER_MANUAL.md) for a walkthrough of the form workflow, navigation and data persistence.
-
-## Email Submission Backend
-
-The "Submit & Email" button on the sea experience page sends the collected form
-data to `submit_application.php`. The script uses **PHPMailer** to deliver the
-application via SMTP. To enable this feature you need PHP 8+ and Composer
-installed locally.
-
-Run `composer install` in the project root to install PHPMailer and set the
-following environment variables for your SMTP server (see
-[.env.example](.env.example) for a template):
-
-- `SMTP_HOST`
-- `SMTP_USER`
-- `SMTP_PASS`
-- `SMTP_PORT` (defaults to 465 if unset)
-- `APPLICATION_RECEIVER` – email address that receives the submissions
-
-Once configured, serve the project with a PHP-capable server so the PHP script
-can run when the form is submitted.
+For form navigation and data persistence details see [USER_MANUAL.md](USER_MANUAL.md).

--- a/submit_application.php
+++ b/submit_application.php
@@ -15,6 +15,26 @@ try {
         exit;
     }
 
+    $mysqli = new mysqli(
+        getenv('DB_HOST'),
+        getenv('DB_USER'),
+        getenv('DB_PASS'),
+        getenv('DB_NAME')
+    );
+    if ($mysqli->connect_error) {
+        throw new Exception('Database connection failed: ' . $mysqli->connect_error);
+    }
+    $stmt = $mysqli->prepare('INSERT INTO applications (personal, experiences) VALUES (?, ?)');
+    if (!$stmt) {
+        throw new Exception('Prepare failed: ' . $mysqli->error);
+    }
+    $personalJson = json_encode($payload['personal'] ?? []);
+    $experienceJson = json_encode($payload['experiences'] ?? []);
+    $stmt->bind_param('ss', $personalJson, $experienceJson);
+    $stmt->execute();
+    $stmt->close();
+    $mysqli->close();
+
     $mail = new PHPMailer(true);
 
     $mail->isSMTP();


### PR DESCRIPTION
## Summary
- integrate MySQL in `submit_application.php`
- extend `.env.example` with database settings
- rewrite README with XAMPP + MySQL setup instructions

## Testing
- `npm install` *(fails: 403 Forbidden due to disabled network)*
- `composer install` *(fails: composer not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864df46575083259a5c030783e436af